### PR TITLE
Add roll-forward validation CLI

### DIFF
--- a/roll_forward_cli.py
+++ b/roll_forward_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import argparse
+import pandas as pd
+from logic_jet import load_gl_for_jet
+from logic_comparison import load_tb, perform_roll_forward_test
+
+
+def main() -> None:
+    """Command line utility to verify prior TB + GL = current TB."""
+    parser = argparse.ArgumentParser(
+        description="Verify that prior trial balance and journal entries roll forward to the current trial balance"
+    )
+    parser.add_argument("--gl", required=True, help="Path to the general ledger file (csv or xlsx)")
+    parser.add_argument("--prev", required=True, help="Path to the prior trial balance file (csv or xlsx)")
+    parser.add_argument("--curr", required=True, help="Path to the current trial balance file (csv or xlsx)")
+    parser.add_argument("--gl-header", type=int, default=0, help="Header row index for the GL file")
+    parser.add_argument("--prev-header", type=int, default=0, help="Header row index for the prior TB file")
+    parser.add_argument("--curr-header", type=int, default=0, help="Header row index for the current TB file")
+
+    args = parser.parse_args()
+
+    gl_df = load_gl_for_jet(args.gl, header_row=args.gl_header)
+    pre_tb_df = load_tb(args.prev, header_row=args.prev_header)
+    cur_tb_df = load_tb(args.curr, header_row=args.curr_header)
+
+    diff_df = perform_roll_forward_test(gl_df, pre_tb_df, cur_tb_df)
+
+    if diff_df.empty:
+        print("\N{white heavy check mark} Roll-forward test passed. No differences found.")
+    else:
+        print("\N{warning sign} Roll-forward differences detected:\n")
+        print(diff_df.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small command line utility `roll_forward_cli.py` for validating that the prior trial balance plus journal entries equal the current trial balance

## Testing
- `python -m py_compile logic_comparison.py logic_jet.py streamlit_app.py roll_forward_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6884b504b3908331ab1d56346325bbf5